### PR TITLE
Add Docker packaging (Dockerfile + unbound sidecar + compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+.git
+.github
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM rust:1.82-bookworm AS builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release --locked
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash curl python3 dnsutils ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --no-create-home --uid 10001 --shell /usr/sbin/nologin evade
+
+COPY --from=builder /build/target/release/evade-proxy /usr/local/bin/evade-proxy
+COPY scripts /opt/xdp-dns-evadeproxy/scripts
+COPY probe/domains.json /opt/xdp-dns-evadeproxy/probe/domains.json
+
+RUN mkdir -p /etc/unbound /var/lib/evade-proxy /run/evade-proxy /opt/xdp-dns-evadeproxy/data \
+    && chown -R evade:evade /etc/unbound /var/lib/evade-proxy /run/evade-proxy /opt/xdp-dns-evadeproxy/data
+
+ENV XDP_PREFIX=/opt/xdp-dns-evadeproxy
+EXPOSE 5335/udp 5335/tcp 5337/udp 5337/tcp 5339/tcp
+
+USER evade
+ENTRYPOINT ["/usr/local/bin/evade-proxy"]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ handle /probe/* {
 
 No ejecutar a la vez que un `evade_proxy` en Python: mismos puertos.
 
+## Docker
+
+Alternativa a `install.sh` para quien prefiera contenedores. El stack de ejemplo
+levanta evade-proxy, un `unbound` recursivo con validación DNSSEC (su upstream
+en `127.0.0.1:5336`/`:5338`) y el bucle que sincroniza blocklist + prefijos
+Cloudflare:
+
+```sh
+cp evade-proxy.env.example evade-proxy.env   # PROBE_TOKEN=… si usas la sonda
+docker compose up -d --build
+```
+
+`unbound` y `blocklist-updater` se unen al *network namespace* de
+`evade-proxy` (`network_mode: "service:evade-proxy"`) porque el proxy siempre
+resuelve su upstream en `127.0.0.1` (ver tabla de puertos más abajo) — no hay
+forma de apuntarlo a otro contenedor por nombre de servicio.
+
+Para ponerlo delante de un servidor DNS que ya use `network_mode: host` en el
+mismo host (p. ej. AdGuard Home), añade `network_mode: host` al servicio
+`evade-proxy`, quita su bloque `ports:`, y apunta el DNS upstream de ese
+servidor a `127.0.0.1:5335`.
+
 ## Lista de IPs bloqueadas
 
 `scripts/update-blocked-ips.sh`, timer cada 15 s:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# Example stack: evade-proxy + a DNSSEC-validating unbound resolver it sits
+# in front of + the blocklist/Cloudflare-prefix updater loop.
+#
+# unbound and blocklist-updater join evade-proxy's network namespace
+# (network_mode: "service:evade-proxy") because evade-proxy always dials
+# its upstream on 127.0.0.1 (see README "Puertos").
+#
+# To run this in front of a DNS server that already publishes host ports
+# 53/853/... (e.g. AdGuard Home in network_mode: host on the same box),
+# add `network_mode: host` to the evade-proxy service, drop its `ports:`
+# section, and point that server's upstream DNS at 127.0.0.1:5335.
+services:
+  evade-proxy:
+    build: .
+    restart: unless-stopped
+    env_file:
+      - evade-proxy.env.example
+    ports:
+      - "5335:5335/udp"
+      - "5335:5335/tcp"
+      - "5339:5339/tcp"
+    volumes:
+      - unbound-conf:/etc/unbound
+      - evade-state:/var/lib/evade-proxy
+      - evade-run:/run/evade-proxy
+
+  unbound:
+    build:
+      context: .
+      dockerfile: docker/unbound.Dockerfile
+    restart: unless-stopped
+    network_mode: "service:evade-proxy"
+    depends_on:
+      - evade-proxy
+
+  blocklist-updater:
+    build: .
+    restart: unless-stopped
+    entrypoint: ["/opt/xdp-dns-evadeproxy/scripts/docker-update-loop.sh"]
+    env_file:
+      - evade-proxy.env.example
+    network_mode: "service:evade-proxy"
+    volumes:
+      - unbound-conf:/etc/unbound
+    depends_on:
+      - evade-proxy
+
+volumes:
+  unbound-conf:
+  evade-state:
+  evade-run:

--- a/docker/unbound.Dockerfile
+++ b/docker/unbound.Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+# Minimal DNSSEC-validating recursive resolver, upstream of evade-proxy in
+# the example Docker Compose stack. It must run in the same network
+# namespace as the evade-proxy container (127.0.0.1:5336 / :5338).
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        unbound dns-root-data \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY docker/unbound.conf /etc/unbound/unbound.conf
+# Seed the DNSSEC trust anchor from dns-root-data (RFC 5011 keeps it fresh
+# afterwards). This mirrors /usr/libexec/unbound-helper root_trust_anchor_update,
+# which Debian's unbound.service normally runs via systemd.
+RUN mkdir -p /var/lib/unbound \
+    && cp /usr/share/dns/root.key /var/lib/unbound/root.key \
+    && chown -R unbound:unbound /var/lib/unbound
+
+USER unbound
+
+ENTRYPOINT ["unbound", "-d", "-c", "/etc/unbound/unbound.conf"]

--- a/docker/unbound.conf
+++ b/docker/unbound.conf
@@ -1,0 +1,19 @@
+# Full recursive, DNSSEC-validating resolver for the Docker packaging of
+# evade-proxy. Listens only on loopback: it must share the network
+# namespace of the evade-proxy container (see docker-compose.yml).
+server:
+    verbosity: 1
+    interface: 127.0.0.1@5336
+    interface: 127.0.0.1@5338
+    do-ip6: no
+    access-control: 127.0.0.1/32 allow
+    root-hints: "/usr/share/dns/root.hints"
+    auto-trust-anchor-file: "/var/lib/unbound/root.key"
+    hide-identity: yes
+    hide-version: yes
+    harden-glue: yes
+    harden-dnssec-stripped: yes
+    use-caps-for-id: yes
+    qname-minimisation: yes
+    prefetch: yes
+    username: "unbound"

--- a/scripts/docker-update-loop.sh
+++ b/scripts/docker-update-loop.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Docker-only entrypoint for the blocklist-updater service: replicates
+# update-blocked-ips.timer (systemd, every 15s) without systemd.
+set -euo pipefail
+
+INTERVAL="${UPDATE_INTERVAL:-15}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/update-cloudflare-prefixes.py" || true
+
+while true; do
+    "$SCRIPT_DIR/update-blocked-ips.sh" || true
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile` builds `evade-proxy` (Rust) and ships it in a slim runtime image alongside the existing `scripts/` blocklist + Cloudflare-prefix updaters, running as a non-root user.
- `docker/unbound.Dockerfile` + `docker/unbound.conf`: minimal DNSSEC-validating recursive `unbound`, the upstream evade-proxy dials on `127.0.0.1:5336`/`:5338`.
- `docker-compose.yml`: wires `evade-proxy`, `unbound`, and a new `blocklist-updater` service (loop wrapper around the existing `update-blocked-ips.sh` / `update-cloudflare-prefixes.py`, replicating `update-blocked-ips.timer` without systemd). `unbound` and `blocklist-updater` join `evade-proxy`'s network namespace (`network_mode: "service:evade-proxy"`) since the proxy always dials its upstream on loopback (`LISTEN_HOST`/`UPSTREAM_HOST` are hardcoded to `127.0.0.1`).
- `evade-proxy.env.example` is reused directly as the compose `env_file` — no new/duplicate env file.
- README: new "## Docker" section, including how to front an existing host-network DNS server (e.g. AdGuard Home) with `network_mode: host`.

This is an alternative to `scripts/install.sh` for anyone who'd rather run this in containers than install a systemd service directly on the host.

## Test plan
- [x] `docker build -t evade-proxy .` — builds clean, binary compiled with `cargo build --release --locked`.
- [x] `docker build -f docker/unbound.Dockerfile -t evade-unbound .` — builds clean.
- [x] `docker compose up -d --build` — all three services (`evade-proxy`, `unbound`, `blocklist-updater`) come up and stay up.
- [x] `blocklist-updater` logs confirm blocklist + Cloudflare prefixes load (`evade-proxy` log: `loaded 1 blocked IPv4, 0 blocked IPv6, 320 Cloudflare IPv4 intervals, 45 IPv6 intervals`).
- [x] End-to-end DNS query through the whole chain from inside the stack: `dig @127.0.0.1 -p 5335 example.com` and `cloudflare.com` return real, correctly-resolved answers via `evade-proxy :5335 → unbound :5336`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)