### PR TITLE
Skip question-name decode when no redirect rules are loaded

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -321,15 +321,21 @@ impl App {
             .read()
             .expect("redirect lock poisoned")
             .clone();
-        let domain = question_name(packet);
-        let test_redirect = domain
-            .as_ref()
-            .and_then(|domain| {
-                self.test_redirects
-                    .get(domain)
-                    .or_else(|| temporary_redirects.get(domain))
-            })
-            .filter(|redirect| redirect.expires_at.is_none_or(|expires| expires > epoch()));
+        // Decoding the question name allocates (labels, lowercasing, join). Only pay
+        // for it when some redirect rule actually exists — in production neither map
+        // is populated most of the time, so this is skipped on the common path.
+        let has_redirects = !self.test_redirects.is_empty() || !temporary_redirects.is_empty();
+        let test_redirect = if has_redirects {
+            question_name(packet)
+                .and_then(|domain| {
+                    self.test_redirects
+                        .get(&domain)
+                        .or_else(|| temporary_redirects.get(&domain))
+                })
+                .filter(|redirect| redirect.expires_at.is_none_or(|expires| expires > epoch()))
+        } else {
+            None
+        };
         if test_redirect.is_none() && data.blocked_v4.is_empty() && data.blocked_v6.is_empty() {
             return 0;
         }


### PR DESCRIPTION
## Summary
- `rewrite()` decoded the DNS question name on every packet just to check
  it against the redirect maps (`test_redirects` from `--redirect`,
  `temporary_redirects` from `redirects.txt`). Decoding allocates per
  label plus a final `join`.
- In production `test_redirects` is always empty (only usable together
  with `--test`), and `temporary_redirects` is only non-empty while the
  residential probe has an active `verified-pool` override running — so
  most of the time both maps are empty and the decode never had a chance
  of matching anything.
- Check `has_redirects = !test_redirects.is_empty() || !temporary_redirects.is_empty()`
  first (no packet access needed) and only call `question_name()` when a
  redirect could actually apply. When any redirect rule is loaded,
  behavior is identical to before.

## Test plan
- [x] `cargo test --locked` (5/5 passing) — covers both branches: pure
  block-evasion (no redirects loaded) and an active `--test` redirect.