### PR TITLE
CI: cache deps, audit dependencies, build Docker images, dedupe runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,37 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cargo test --locked
       - name: Release build
         run: cargo build --release --locked
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Audit dependencies
+        run: cargo audit
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build evade-proxy image
+        run: docker build -t evade-proxy:ci .
+      - name: Build unbound sidecar image
+        run: docker build -f docker/unbound.Dockerfile -t evade-proxy-unbound:ci .


### PR DESCRIPTION
## Summary
- **Cache**: `Swatinem/rust-cache@v2` after the toolchain step — avoids
  recompiling every dependency from scratch on each run.
- **Audit**: new `audit` job runs `cargo audit` (installed via
  `taiki-e/install-action@v2`) against `Cargo.lock` to catch known
  RustSec advisories. This is a blocking check — flag if you'd rather
  have it advisory-only (`continue-on-error: true`).
- **Docker**: new `docker` job builds both `Dockerfile` (evade-proxy)
  and `docker/unbound.Dockerfile` (sidecar), now that Docker packaging
  is on `main`. Verified locally — both build clean.
- **Concurrency**: workflow-level `concurrency` group cancels a
  superseded run when new commits land on the same PR/ref.

## Test plan
- [x] `cargo test --locked` (5/5 passing)
- [x] `docker build -t evade-proxy:ci .` — builds clean locally
- [x] `docker build -f docker/unbound.Dockerfile -t evade-proxy-unbound:ci .` — builds clean locally
- [x] Verified `Swatinem/rust-cache@v2` and `taiki-e/install-action@v2` exist and the `v2` tag is published