### PR TITLE
Add Dependabot for cargo, GitHub Actions and Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly, grouped version-update checks
  for the three ecosystems this repo actually uses:
  - `cargo` — Cargo.toml/Cargo.lock
  - `github-actions` — the workflow files, including the third-party
    actions pinned in #4 (Swatinem/rust-cache, taiki-e/install-action, …)
  - `docker` — two separate entries (`/` and `/docker`), one per
    Dockerfile, since Dependabot's docker ecosystem only scans the
    directory given, not recursively
- Updates are grouped per ecosystem so this doesn't spam one PR per
  dependency.

## Notes for merging
- No repo settings need to change for this to take effect — GitHub
  enables Dependabot version updates simply by having this file on the
  default branch.
- This does **not** enable "Dependabot security updates" (the
  vulnerability-triggered, out-of-schedule PRs) — that's a separate
  toggle under Settings → Security → Code security, independent of this
  file, if you want it on top of the scheduled updates here and the
  `cargo audit` job from #4.
- Heads up: Dependabot auto-pauses if its PRs go unreviewed for a while,
  so it needs occasional engagement to keep running.

## Test plan
- [x] Validated `.github/dependabot.yml` YAML syntax
- [x] Confirmed via Dependabot's own docker file-fetcher source
  (`dependabot-core`) that it detects any filename matching
  `dockerfile|containerfile` (case-insensitive) within the configured
  `directory`, so `docker/unbound.Dockerfile` is picked up correctly