### PR TITLE
Publish multi-arch Docker images to GHCR on push and release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,114 @@
+name: docker-publish
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set platform pair for artifact naming
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # latest        -> every push to main
+      # latest-stable  + semver tags -> only on a published GitHub Release
+      - name: Extract tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest-stable,enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/%s@sha256:%s ' "$IMAGE_NAME" *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Action required after merge (one-time)

GHCR does **not** inherit a linked repo's visibility, only its access
permissions — the package will be created **private** on first publish.
After the first successful run on `main`, someone with admin on this
repo needs to:

1. Go to Packages → `xdp-dns-evadeproxy` → Package settings.
2. Change visibility → Public.

That's the only manual step. Confirmed against GitHub's own docs that
nothing else needs touching:
- `GITHUB_TOKEN` permissions: the `permissions: { packages: write,
  contents: read }` block declared in this workflow overrides whatever
  the repo's default Workflow permissions setting is — no need to
  change anything under Settings → Actions.
- No new secrets needed — `GITHUB_TOKEN` is automatic.
- Packages is enabled by default on repos, no separate toggle expected.

## Summary
- New `docker-publish` workflow builds and pushes the `evade-proxy`
  image to `ghcr.io/oihalitz/xdp-dns-evadeproxy`.
- **Multi-arch, truly parallel**: `linux/amd64` and `linux/arm64` build
  on separate native runners (`ubuntu-24.04` / `ubuntu-24.04-arm`) at
  the same time — no QEMU emulation, which matters here given
  `Cargo.toml` uses `lto = "fat"` + `codegen-units = 1`.
- **Caching**: GitHub Actions cache backend (`type=gha`), scoped per
  platform so the two parallel builds don't clobber each other's cache.
- **Tagging**:
  | Trigger | Tag(s) |
  |---|---|
  | push to `main` | `latest` |
  | published Release (e.g. `v1.2.0`) | `latest-stable`, `1.2.0`, `1.2` |
- Each platform job pushes by digest only; a final `merge` job combines
  both digests into one multi-arch manifest under the final tags via
  `docker buildx imagetools create` — the standard pattern for
  matrix-built multi-platform images.
- Only the main `evade-proxy` image is published (not the unbound
  sidecar). No release binaries are attached — GHCR only, per request.

## Test plan
- [x] YAML validated
- [x] `actionlint` clean (0 findings) across all workflow files —
  covers shellcheck on every `run:` block and schema validation of
  every action's `with:` inputs
- [x] Confirmed the exact major-version tags for all 7 actions used
  against the GitHub API (not from memory)
- [ ] Not exercised end-to-end (no `buildx` available in the review
  sandbox) — first real run will be the first push to `main` after
  merge, worth watching